### PR TITLE
Fix whitespace replacement

### DIFF
--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -28,9 +28,11 @@ function processRequest(r: WebRequest.OnBeforeRequestDetailsType): WebRequest.Bl
 
   // Cut first bang from query text
   let bang = '';
-  queryText = queryText.replace(/!\w+/, (substr) => {
-    bang = substr.substring(1);
-    return '';
+  queryText = queryText.replace(/(?:^\s*|(\b)\s+)!(\w+)(?:\s+(\b)|\s*$)/, (_, leftBoundary, gBang, rightBoundary): string => {
+    bang = gBang;
+    const wordToLeft = leftBoundary !== undefined;
+    const wordToRight = rightBoundary !== undefined;
+    return wordToRight && wordToLeft ? ' ' : '';
   });
   if (!bang) { return {}; }
 


### PR DESCRIPTION
Hey again, I noticed a small error in the previous PR. The bang gets replaced without consideration of the surrounding whitespace. This change trims whitespace when the bang is at either end of the string, and leaves only one space between words when in the middle.