### PR TITLE
Add Startpage

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,7 @@
     "*://*.bing.com/*",
     "*://*.duckduckgo.com/*",
     "*://*.qwant.com/*",
+    "*://*.startpage.com/*",
     "webRequest",
     "webRequestBlocking",
     "storage"

--- a/src/lib/bangs.ts
+++ b/src/lib/bangs.ts
@@ -113,7 +113,7 @@ export async function getBangs(): Promise<BangsType> {
   let { bangs } = await browser.storage.sync.get('bangs');
 
   // Check the first object entry. Not super efficient but whatever.
-  for (const [, value] of Object.entries(bangs)) {
+  for (const [, value] of Object.entries(bangs ?? {})) {
     if (typeof value === 'string') {
       // The value is a string so it's old and needs converting.
       bangs = convertLegacyBangs(bangs);


### PR DESCRIPTION
- Only listen for master-frame requests
- Added Startpage.com GET & POST support (on POST requests it will cancel the request and redirect the tab manually)
- Fixed a bug where getBangs tried to get entries of undefined