### PR TITLE
Limit extension to www for .google.com

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,13 @@
 {
   "manifest_version": 2,
   "name": "Custom Bang Search",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Allows you to use custom bangs inside the search bar",
   "icons": {
     "48": "icons/icon_48.png"
   },
   "permissions": [
-    "*://*.google.com/*",
+    "*://www.google.com/*",
     "*://*.bing.com/*",
     "*://*.duckduckgo.com/*",
     "*://*.qwant.com/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custombangsearch",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "A web extension that allows you to use DuckDuckGo-like custom bangs directly from the address bar",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Disallows extension to access other subdomains like mail.google.com or
drive.google.com, instead only to the search subdomain. Closes #12