### PR TITLE
Call bangChanged only when input loses focus. 

### DIFF
--- a/src/options/components/BangsTableRow.tsx
+++ b/src/options/components/BangsTableRow.tsx
@@ -69,7 +69,7 @@ export default function BangsTableRow(props: PropsType): React.ReactElement {
 
   return (
     <tr>
-      <td><input type="text" value={bang} onChange={bangChanged} style={bangCss} /></td>
+      <td><input type="text" value={bang} onBlur={bangChanged} style={bangCss} /></td>
       <td><input type="text" value={bangInfo.url} onChange={urlChanged} /></td>
       <td><button type="button" title="Trash" onClick={trashBtnlicked}>🗑</button></td>
     </tr>


### PR DESCRIPTION
Hey there. Nice extension!

Ran into #11 right out of the gate while setting up the `!gi` and `!gs` bangs for Google Images and Scholar, respectively. 

I believe a decent fix is to only call `bangChanged` when the input loses focus rather than with React's `onChange`, which (TIL) [fires every time the user types something in a field](https://reactjs.org/docs/dom-elements.html#onchange).

If we're lucky, that's as simple as changing [Line 72 of `BangsTableRow.tsx`](https://github.com/psidex/CustomBangSearch/blob/master/src/options/components/BangsTableRow.tsx#L72-L73) to use `onBlur`:
```html
      <td><input type="text" value={bang} onBlur={bangChanged} style={bangCss} /></td>
```

I have *not* tested this.

Since it's such a small change, I went ahead and opened a PR instead of just speculating. Hope it's helpful!