### PR TITLE
Replace unascii exclamation mark of first letter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,6 @@ sketch
 .ionide
 
 # End of https://www.toptal.com/developers/gitignore/api/node,visualstudiocode,react
+
+### JetBrains ###
+.idea

--- a/src/background/requests.ts
+++ b/src/background/requests.ts
@@ -1,7 +1,7 @@
-import browser, { WebRequest } from 'webextension-polyfill';
+import browser, {WebRequest} from 'webextension-polyfill';
 
-import { getBangsLookup } from './lookup';
-import { getIgnoredDomains } from './ignoreddomains';
+import {getBangsLookup} from './lookup';
+import {getIgnoredDomains} from './ignoreddomains';
 
 const possibleQueryParams = ['q', 'query', 'eingabe'];
 
@@ -19,6 +19,22 @@ function constructRedirect(redirectUrl: string, queryText: string): string {
     return (new URL(redirectUrl)).origin;
   }
   return redirectUrl.replace(/%s/g, encodeURIComponent(queryText));
+}
+
+/**
+ * If the first letter of 'queryText' is an unascii exclamation mark, replace it to the ascii exclamation mark.
+ * @param queryText
+ */
+function replaceUnasciiExclamationMark(queryText: string) {
+  const unasciiExclamationMarks = [
+    "！", // Chinese exclamation mark
+  ]
+  for (let unasciiExclamationMark of unasciiExclamationMarks) {
+    if (queryText.charAt(0) === unasciiExclamationMark) {
+      return "!" + queryText.substring(1);
+    }
+  }
+  return queryText;
 }
 
 /**
@@ -58,6 +74,8 @@ async function getRedirects(
   if (queryText.length === 0) {
     return Promise.resolve([]);
   }
+
+  queryText = replaceUnasciiExclamationMark(queryText);
 
   // Cut first bang from query text, it can be anywhere in the string.
   let bang = '';
@@ -107,11 +125,11 @@ export default async function processRequest(
 
   // Open all URLs (except the first) in new tabs
   for (let i = 1; i < redirections.length; i += 1) {
-    browser.tabs.create({ url: redirections[i] });
+    browser.tabs.create({url: redirections[i]});
   }
 
   // Finally send the current tab to the first in the array.
-  browser.tabs.update(r.tabId, { url: redirections[0] });
+  browser.tabs.update(r.tabId, {url: redirections[0]});
 
   return Promise.resolve();
 }

--- a/src/background/requests.ts
+++ b/src/background/requests.ts
@@ -22,16 +22,18 @@ function constructRedirect(redirectUrl: string, queryText: string): string {
 }
 
 /**
- * If the first letter of 'queryText' is an unascii exclamation mark, replace it to the ascii exclamation mark.
- * @param queryText
+ * Replace the first non ascii exclamation mark with the ascii exclamation mark.
+ * @param queryText may be something like: `！g rust` (there is a Chinese exclamation mark `！` in it)
+ * @returns         may be something like: `!g rust`
+ *                  (the non ascii exclamation mark `！` has been replaced with the normal ascii exclamation mark `!`)
  */
-function replaceUnasciiExclamationMark(queryText: string) {
-  const unasciiExclamationMarks = [
+function replaceFirstNonAsciiExclamationMark(queryText: string) {
+  const nonAsciiExclamationMarks = [
     "！", // Chinese exclamation mark
   ]
-  for (let unasciiExclamationMark of unasciiExclamationMarks) {
-    if (queryText.charAt(0) === unasciiExclamationMark) {
-      return "!" + queryText.substring(1);
+  for (let nonAsciiExclamationMark of nonAsciiExclamationMarks) {
+    if (queryText.indexOf(nonAsciiExclamationMark) > -1) {
+      return queryText.replace(nonAsciiExclamationMark, "!")
     }
   }
   return queryText;
@@ -75,7 +77,7 @@ async function getRedirects(
     return Promise.resolve([]);
   }
 
-  queryText = replaceUnasciiExclamationMark(queryText);
+  queryText = replaceFirstNonAsciiExclamationMark(queryText);
 
   // Cut first bang from query text, it can be anywhere in the string.
   let bang = '';


### PR DESCRIPTION
If the first letter of  `queryText`  is an unascii exclamation mark, replace it with the ascii exclamation mark.
It helps the Chinese a lot. I don't know if other countries have this problem or not, so I just defined the  `unasciiExclamationMarks`  as an array.
